### PR TITLE
Adaptations to use weaviate multi tenants feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,32 @@ HF_TOKEN=
 
 # ENABLE-LLAMA2?-(True or False)
 LLAMA2-7B-CHAT-HF=
+
+# Optional parameters when using azure OpenAI. 
+
+# set type, should be "azure".
+#OPENAI_API_TYPE="azure"
+
+# resource name is the first part of your endpoint. 
+# for example if your endpoint is XXX.openai.azure.com, it is XXX
+#AZURE_OPENAI_RESOURCE_NAME=
+
+# model used for embeddings
+#AZURE_OPENAI_EMBEDDING_MODEL="text-embedding-ada-002"
+
+# your azure openai endpoint. should be https://XXX.openai.azure.com
+#OPENAI_API_BASE=
+
+# your azure openai key
+#OPENAI_API_KEY=
+
+# your azure openai model delpoyment. typically gpt-4
+#OPENAI_MODEL="gpt-4"
+
+# waiting time  between queries, in ms. this is required if you have per minute quota, 
+# which is usual with Azure OpenAI
+# for example, if you have a limit of 240k tokens per minute, if your chunks are 
+# 400 tokens max, then 100ms between queries should be fine
+# if you get error 429 from weaviate, then increase this value.
+#WAIT_TIME_BETWEEN_INGESTION_QUERIES_MS="100"
+

--- a/goldenverba/components/embedding/interface.py
+++ b/goldenverba/components/embedding/interface.py
@@ -1,4 +1,7 @@
 import re
+import os
+import time
+from dotenv import load_dotenv
 
 from tqdm import tqdm
 from wasabi import msg
@@ -13,6 +16,7 @@ from goldenverba.components.schema.schema_generation import (
     strip_non_letters,
 )
 
+load_dotenv()
 
 class Embedder(VerbaComponent):
     """
@@ -113,6 +117,10 @@ class Embedder(VerbaComponent):
                                 client.batch.add_data_object(
                                     properties, class_name, vector=chunk.vector
                                 )
+                            
+                            wait_time_ms = int(os.getenv("WAIT_TIME_BETWEEN_INGESTION_QUERIES_MS","0"))
+                            if wait_time_ms>0:
+                                time.sleep(float(wait_time_ms)/1000)
 
                 self.check_document_status(
                     client,

--- a/goldenverba/verba_manager.py
+++ b/goldenverba/verba_manager.py
@@ -162,13 +162,25 @@ class VerbaManager:
         additional_header = {}
         client = None
 
+        openai_header_key_name = "X-OpenAI-Api-Key"
+
         # Check OpenAI ENV KEY
         try:
             import openai
 
             openai_key = os.environ.get("OPENAI_API_KEY", "")
+            if "OPENAI_API_TYPE" in os.environ:
+                openai.api_type = os.getenv("OPENAI_API_TYPE")
+            if "OPENAI_API_BASE" in os.environ:
+                openai.api_base = os.getenv("OPENAI_API_BASE")
+            if "OPENAI_API_VERSION" in os.environ:
+                openai.api_version = os.getenv("OPENAI_API_VERSION")
+
+            if os.getenv("OPENAI_API_TYPE") == "azure":
+                openai_header_key_name = "X-Azure-Api-Key"            
+
             if openai_key != "":
-                additional_header["X-OpenAI-Api-Key"] = openai_key
+                additional_header[openai_header_key_name] = openai_key
                 self.environment_variables["OPENAI_API_KEY"] = True
                 openai.api_key = openai_key
             else:
@@ -215,7 +227,7 @@ class VerbaManager:
             msg.info("Using Weaviate Embedded")
             self.weaviate_type = "Weaviate Embedded"
             client = weaviate.Client(
-                additional_headers={"X-OpenAI-Api-Key": openai.api_key},
+                additional_headers={openai_header_key_name: openai.api_key},
                 embedded_options=EmbeddedOptions(),
             )
 


### PR DESCRIPTION
This PR enables the use of multiple instances of Verba with a single instance of Weaviate, which natively supports multi-tenancy.

If no tenant is provided at startup, the default tenant default_tenant will be used.